### PR TITLE
Fix include guard

### DIFF
--- a/lda-model.h
+++ b/lda-model.h
@@ -1,5 +1,5 @@
 #ifndef LDA_MODEL_H
-#define LDA_MODEL
+#define LDA_MODEL_H
 
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
I was playing around with the lda-c code and I noticed there was a typo in the include guard of lda-model.h.
