### PR TITLE
Prevent documents from being selected as a seed more than once.

### DIFF
--- a/lda-estimate.c
+++ b/lda-estimate.c
@@ -147,6 +147,14 @@ void run_em(char* start, char* directory, corpus* corpus)
         lda_mle(model, ss, 0);
         model->alpha = INITIAL_ALPHA;
     }
+    else if (strncmp(start, "manual=",7)==0)
+    {
+        model = new_lda_model(corpus->num_terms, NTOPICS);
+        ss = new_lda_suffstats(model);
+        manual_initialize_ss(start + 7, ss, model, corpus);
+        lda_mle(model, ss, 0);
+        model->alpha = INITIAL_ALPHA;
+    }
     else
     {
         model = load_lda_model(start);
@@ -334,7 +342,7 @@ int main(int argc, char* argv[])
     }
     else
     {
-        printf("usage : lda est [initial alpha] [k] [settings] [data] [random/seeded/*] [directory]\n");
+        printf("usage : lda est [initial alpha] [k] [settings] [data] [random/seeded/manual=filename/*] [directory]\n");
         printf("        lda inf [settings] [model] [data] [name]\n");
     }
     return(0);

--- a/lda-model.c
+++ b/lda-model.c
@@ -119,14 +119,31 @@ void random_initialize_ss(lda_suffstats* ss, lda_model* model)
 void corpus_initialize_ss(lda_suffstats* ss, lda_model* model, corpus* c)
 {
     int num_topics = model->num_topics;
-    int i, k, d, n;
+    int i, j, k, d, n;
     document* doc;
-
+    int seen[num_topics][NUM_INIT];
+    int already_selected;
+        
     for (k = 0; k < num_topics; k++)
     {
         for (i = 0; i < NUM_INIT; i++)
         {
-            d = floor(myrand() * c->num_docs);
+            do
+            {
+              d = floor(myrand() * c->num_docs);
+
+              already_selected = 0;
+              for (j = 0;j < k;j++)
+              {
+                if (seen[j][i] == d)
+                {
+                  already_selected = 1;
+                  printf("skipping duplicate seed document %d\n", d);
+                }
+              }
+            } while (already_selected);
+            seen[k][i] = d;
+            
             printf("initialized with document %d\n", d);
             doc = &(c->docs[d]);
             for (n = 0; n < doc->length; n++)

--- a/lda-model.h
+++ b/lda-model.h
@@ -16,6 +16,7 @@ void save_lda_model(lda_model*, char*);
 lda_model* new_lda_model(int, int);
 lda_suffstats* new_lda_suffstats(lda_model* model);
 void corpus_initialize_ss(lda_suffstats* ss, lda_model* model, corpus* c);
+void manual_initialize_ss(char *seedfile, lda_suffstats* ss, lda_model* model, corpus* c);
 void random_initialize_ss(lda_suffstats* ss, lda_model* model);
 void zero_initialize_ss(lda_suffstats* ss, lda_model* model);
 void lda_mle(lda_model* model, lda_suffstats* ss, int estimate_alpha);

--- a/readme.txt
+++ b/readme.txt
@@ -81,15 +81,16 @@ B. TOPIC ESTIMATION
 
 Estimate the model by executing:
 
-     lda est [alpha] [k] [settings] [data] [random/seeded/*] [directory]
+     lda est [alpha] [k] [settings] [data] [random/seeded/manual=filename/*] [directory]
 
 The term [random/seeded/*] > describes how the topics will be
 initialized.  "Random" initializes each topic randomly; "seeded"
 initializes each topic to a distribution smoothed from a randomly
-chosen document; or, you can specify a model name to load a
-pre-existing model as the initial model (this is useful to continue EM
-from where it left off).  To change the number of initial documents
-used, edit lda-estimate.c.
+chosen document; "manual=filename" will load the document numbers to
+use as seeds from the file specified (one per line); or, you can
+specify a model name to load a pre-existing model as the initial model
+(this is useful to continue EM from where it left off).  To change the
+number of initial documents used, edit lda-estimate.c.
 
 The model (i.e., \alpha and \beta_{1:K}) and variational posterior
 Dirichlet parameters will be saved in the specified directory every


### PR DESCRIPTION
Running topic estimation in 'seeded' mode, it was possible to seed two topics with the same document. This patch fixes that behavior.

I've been careful to support values for NUM_INIT other than 1, though I have to confess to not understanding why one would want that/what it would mean to initialize a topic with the sums of multiple different documents.
